### PR TITLE
Change 'text' property to JavaScript undefined

### DIFF
--- a/src/Config/apexcharts.php
+++ b/src/Config/apexcharts.php
@@ -51,7 +51,7 @@ return [
         ],
 
         'subtitle' => [
-            'text' => 'undefined',
+            'text' => new \Balping\JsonRaw\Raw('undefined'),
             'align' => 'left',
         ],
 


### PR DESCRIPTION
Fixed issue in apexcharts.php where 'text' was incorrectly set to "undefined" as string. This change ensures proper initialization of the 'text' property. The string "undefined" appeared on subtitle by default on generate charts.