### PR TITLE
Fix `Formatter` trait `toJson` and `toVue` methods

### DIFF
--- a/src/Config/apexcharts.php
+++ b/src/Config/apexcharts.php
@@ -4,10 +4,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Font Options
+    | ApexCharts Default Options
     |--------------------------------------------------------------------------
     |
-    | Here you may specify font family and font color.
+    | Here you may define the default options that will be applied to all
+    | ApexCharts rendered using this package. To learn more about each
+    | available option, check the official ApexCharts documentation.
+    |
+    | https://apexcharts.com/docs/options/
     |
     */
 

--- a/src/Traits/Formatter.php
+++ b/src/Traits/Formatter.php
@@ -2,24 +2,25 @@
 
 namespace Akaunting\Apexcharts\Traits;
 
+use Illuminate\Http\JsonResponse;
+
+/** @mixin \Akaunting\Apexcharts\Chart */
 trait Formatter
 {
-    public function toJson()
+    public function toJson(): JsonResponse
     {
-        return response()->json([
-            'id'        => $this->id(),
-            'options'   => $this->getOptions(),
-        ]);
+        return response()->json($this->toVue());
     }
 
     public function toVue(): array
     {
         return [
+            'id'        => $this->getId(),
             'height'    => $this->getHeight(),
             'width'     => $this->getWidth(),
             'type'      => $this->getType(),
-            'options'   => $this->getOptions(),
-            'series'    => json_decode($this->getSeries()),
+            'options'   => json_decode($this->getOptions(), true),
+            'series'    => $this->getSeries(),
         ];
     }
 }

--- a/tests/Feature/ChartsTest.php
+++ b/tests/Feature/ChartsTest.php
@@ -266,18 +266,13 @@ class ChartsTest extends TestCase
 
         $response = $chart->toJson();
 
-        $this->assertEquals(
-            [
+        $this->assertEquals([
             'id',
             'height',
             'width',
             'type',
             'options',
             'series',
-        ],
-            array_keys(
-            json_decode($response->content(), true)
-        )
-        );
+        ], array_keys(json_decode($response->content(), true)));
     }
 }

--- a/tests/Feature/ChartsTest.php
+++ b/tests/Feature/ChartsTest.php
@@ -7,7 +7,6 @@ use Akaunting\Apexcharts\Tests\TestCase;
 
 class ChartsTest extends TestCase
 {
-    /** @test */
     public function testDefaultChart()
     {
         $chart = (new Chart)->setTitle('Users Test Chart');
@@ -16,7 +15,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('line', $chart->getType());
     }
 
-    /** @test */
     public function testPieChart()
     {
         $chart = (new Chart)->setType('pie')
@@ -30,7 +28,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('pie', $chart->getType());
     }
 
-    /** @test */
     public function testDonutChart()
     {
         $chart = (new Chart)->setType('donut')
@@ -42,7 +39,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('donut', $chart->getType());
     }
 
-    /** @test */
     public function testRadialChart()
     {
         $chart = (new Chart)->setType('radial')
@@ -54,7 +50,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('radial', $chart->getType());
     }
 
-    /** @test */
     public function testPolarChart()
     {
         $chart = (new Chart)->setType('polarArea')
@@ -66,7 +61,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('polarArea', $chart->getType());
     }
 
-    /** @test */
     public function testLineChart()
     {
         $chart = (new Chart)->setType('line')
@@ -90,7 +84,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('line', $chart->getType());
     }
 
-    /** @test */
     public function testAreaChart()
     {
         $chart = (new Chart)->setType('area')
@@ -115,7 +108,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('area', $chart->getType());
     }
 
-    /** @test */
     public function testBarChart()
     {
         $chart = (new Chart)->setType('bar')
@@ -153,7 +145,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('bar', $chart->getType());
     }
 
-    /** @test */
     public function testHorizontalBarChart()
     {
         $chart = (new Chart)->setType('bar')
@@ -181,7 +172,6 @@ class ChartsTest extends TestCase
         $this->assertTrue($chart->getHorizontal());
     }
 
-    /** @test */
     public function testHeatmapChart()
     {
         $chart = (new Chart)->setType('heatmap')
@@ -205,7 +195,6 @@ class ChartsTest extends TestCase
         $this->assertEquals('heatmap', $chart->getType());
     }
 
-    /** @test */
     public function testRadarChart()
     {
         $chart = (new Chart)->setType('radar')
@@ -227,5 +216,65 @@ class ChartsTest extends TestCase
         $this->assertEquals($chart->getId(), $chart->container()['chart']->getId());
         $this->assertEquals($chart, $chart->script()['chart']);
         $this->assertEquals('radar', $chart->getType());
+    }
+
+    public function testToVue()
+    {
+        $chart = (new Chart)->setType('line')
+            ->setTitle('Total Users Monthly')
+            ->setSubtitle('From January to March')
+            ->setSeries([
+                'Jan', 'Feb', 'Mar'
+            ])
+            ->setDataset('Users', 'line', [
+                [
+                    'name'  =>  'Active Users',
+                    'data'  =>  [250, 700, 1200]
+                ]
+            ])
+            ->setHeight(250)
+            ->setGridShow(true)
+            ->setStrokeShow(true);
+
+        $this->assertEquals([
+            'id',
+            'height',
+            'width',
+            'type',
+            'options',
+            'series',
+        ] , array_keys($chart->toVue()));
+    }
+
+    public function testToJson()
+    {
+        $chart = (new Chart)->setType('line')
+            ->setTitle('Total Users Monthly')
+            ->setSubtitle('From January to March')
+            ->setSeries([
+                'Jan', 'Feb', 'Mar'
+            ])
+            ->setDataset('Users', 'line', [
+                [
+                    'name'  =>  'Active Users',
+                    'data'  =>  [250, 700, 1200]
+                ]
+            ])
+            ->setHeight(250)
+            ->setGridShow(true)
+            ->setStrokeShow(true);
+
+        $response = $chart->toJson();
+
+        $this->assertEquals([
+            'id',
+            'height',
+            'width',
+            'type',
+            'options',
+            'series',
+        ] , array_keys(
+            json_decode($response->content(), true))
+        );
     }
 }

--- a/tests/Feature/ChartsTest.php
+++ b/tests/Feature/ChartsTest.php
@@ -274,7 +274,8 @@ class ChartsTest extends TestCase
             'type',
             'options',
             'series',
-        ], array_keys(
+        ],
+            array_keys(
             json_decode($response->content(), true)
         )
         );

--- a/tests/Feature/ChartsTest.php
+++ b/tests/Feature/ChartsTest.php
@@ -243,7 +243,7 @@ class ChartsTest extends TestCase
             'type',
             'options',
             'series',
-        ] , array_keys($chart->toVue()));
+        ], array_keys($chart->toVue()));
     }
 
     public function testToJson()
@@ -266,15 +266,17 @@ class ChartsTest extends TestCase
 
         $response = $chart->toJson();
 
-        $this->assertEquals([
+        $this->assertEquals(
+            [
             'id',
             'height',
             'width',
             'type',
             'options',
             'series',
-        ] , array_keys(
-            json_decode($response->content(), true))
+        ], array_keys(
+            json_decode($response->content(), true)
+        )
         );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,34 +9,12 @@ use Orchestra\Testbench\TestCase as TestBenchTestCase;
 class TestCase extends TestBenchTestCase
 {
     /**
-     * Sets the env data to interact as env file values
-     *
-     * @param [type] $app
-     * @return void
+     * Load the package service provider.
      */
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('database.default', 'testing');
-
-        $app['config']->set('database.connection.testing', [
-            'driver'    => 'sqlite',
-            'database'  => ':memory:'
-        ]);
-    }
-
-    // set providers to test the class
     protected function getPackageProviders($app): array
     {
         return [
             Provider::class,
-        ];
-    }
-
-    // With this method I can use the facade instead of all class namespace
-    protected function getPackageAliases($app): array
-    {
-        return [
-            'FirstPackage' => Facade::class
         ];
     }
 }


### PR DESCRIPTION
Really like this library so far, thanks for your work on it!

This PR introduces a fix to both the `toVue` and `toJson` methods inside the `Formatter` trait. The `toVue` method would throw an exception due to `json_decode` being called on the `getSeries()` result which returns an array, rather than on the `getOptions()` result which is a JSON encoded string.

I've also tweaked the config doc to more clearly indicate its purpose and added a link to the docs for user help. In addition, I've also removed some unnecessary `@test` annotations in the existing PHPUnit tests, as the method names are already prefixed with `test`.

 If we're able to get this merged I'd be happy to make some more PR's adding more documentation and such.

Let me know if you'd like anything changed or adjusted. Thanks for your time! 🙏 