### PR TITLE
Always provide a default width to prevent console error

### DIFF
--- a/src/Traits/Formatter.php
+++ b/src/Traits/Formatter.php
@@ -16,7 +16,7 @@ trait Formatter
     {
         return [
             'height'    => $this->getHeight(),
-            'width'     => $this->getWidth(),
+            'width'     => $this->getWidth() ?? '100%',
             'type'      => $this->getType(),
             'options'   => $this->getOptions(),
             'series'    => json_decode($this->getSeries()),


### PR DESCRIPTION
When rendering the result of the `toVue` array to a Vue component without a chart width set, it throws the below console error:

![Screenshot 2024-03-30 at 7 38 53 PM](https://github.com/akaunting/laravel-apexcharts/assets/6421846/00b5b3c9-14d1-46b7-8460-2996d8abe242)

This can be prevented if we just default to a `100%` width if the width is `null`.

My Vue component:

```vue
<template>
    <apexchart
        :type="chart.type"
        :width="chart.width"
        :height="chart.height"
        :series="chart.series"
        :options="chart.options"
    />
</template>

<script>
export default {
    props: {
        chart: {
            type: Object,
            required: true,
        },
    },
};
</script>
```

