### PR TITLE
Inherit site font by default

### DIFF
--- a/src/Config/apexcharts.php
+++ b/src/Config/apexcharts.php
@@ -23,7 +23,7 @@ return [
             'zoom' => [
                 'enabled' => true,
             ],
-            'fontFamily' => 'Nunito',
+            'fontFamily' => 'inherit',
             'foreColor' => '#373d3f',
         ],
 


### PR DESCRIPTION
This PR changes the default `fontFamily` proposed in the config to be `inherit`.

With `inherit`, the default font that is applied in the charts parent will be applied to all elements in the chart.

If a site doesn't have the Nunito font setup, then the fonts are rendered in Times New Roman by default:

![Screenshot 2024-03-30 at 7 43 09 PM](https://github.com/akaunting/laravel-apexcharts/assets/6421846/35fb2a26-afe1-4ab3-9adf-f62b76698317)
