### PR TITLE
Add ID and key to inertia chart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Then, create a simple `chart.vue` component:
 
 <template>
     <apexchart
+        :id="chart.id"
+        :key="chart.id"
         :type="chart.type"
         :width="chart.width"
         :height="chart.height"


### PR DESCRIPTION
I discovered in my application that the Vue 3 Apexcharts component will throw a console error and break when rendering the chart with Inertia if you redirect `back()` from a form on the same page as the chart if you do not have a `key` set on the component:

**Before**:

https://github.com/akaunting/laravel-apexcharts/assets/6421846/f4b5b463-6727-4780-a63f-94023b3f7e0f

**After**:

https://github.com/akaunting/laravel-apexcharts/assets/6421846/f4c71e28-9d04-4708-94d4-9c33020d3f66

I've also set `id` here as well (not necessary for the fix, but might as well).